### PR TITLE
Implement breakpoints

### DIFF
--- a/recursive_blocks/src/Block.tsx
+++ b/recursive_blocks/src/Block.tsx
@@ -60,6 +60,16 @@ export function Block({ block, onUpdate, highlightedBlockId }: Props) {
       }}
     >
       <div className="block-header" style={{ gap: "0.25rem" }}>
+        <button 
+          className="breakpoint-button"
+          onClick={() => {
+            onUpdate({ ...block, hasBreakpoint: !block.hasBreakpoint });
+          }}
+          title="Toggle Breakpoint"
+          style={{ color: block.hasBreakpoint ? "red" : "#ccc", border: "none", background: "none", cursor: "pointer", fontSize: "1.2em", padding: "0 0.2rem" }}
+        >
+          {block.hasBreakpoint ? "\u25CF" : "\u25CB"}
+        </button>
         <div className="block-type">{block.name || block.type.toUpperCase()}</div>
         <div className="block-error-list">
           {block.errors.map((error, index) => (

--- a/recursive_blocks/src/BlockConfig.ts
+++ b/recursive_blocks/src/BlockConfig.ts
@@ -78,9 +78,6 @@ export const blockConfig: Record<BlockType, {
     evaluate: (_block, _inputs, _evaluate, onStepCallback) => {
       // Zero block always returns 0
       const result = 0;
-      if (onStepCallback) {
-        onStepCallback(_block, result);
-      }
       return result;
     },
     checkForErrors: (_block) => {
@@ -100,9 +97,6 @@ export const blockConfig: Record<BlockType, {
         throw new Error("Successor block requires exactly one input.");
       }
       const result = inputs[0] + 1;
-      if (onStepCallback) {
-        onStepCallback(_block, result);
-      }
       return result;
     },
     checkForErrors: (block) => {
@@ -129,9 +123,6 @@ export const blockConfig: Record<BlockType, {
       }
       const i = block.num_values[0].value ?? 0;
       const result = inputs[i-1];
-      if (onStepCallback) {
-        onStepCallback(block, result);
-      }
       return result;
     },
     checkForErrors: (block) => {
@@ -169,9 +160,6 @@ export const blockConfig: Record<BlockType, {
         g_results.push(await evaluate(g_block, inputs, evaluate, onStepCallback));
       }
       const result = await evaluate(block.children[0].block!, g_results, evaluate, onStepCallback);
-      if (onStepCallback) {
-        await onStepCallback(block, result);
-      }
       return result;
     },
     dynamicChildren: (block: BlockData) => {
@@ -212,9 +200,6 @@ export const blockConfig: Record<BlockType, {
       if (inputs[inputs.length - 1] <= 0) {
         // Base case: if the last input is 0, evaluate the base case block
         const result = await evaluate(block.children[0].block!, inputs.slice(0, -1), evaluate, onStepCallback);
-        if (onStepCallback) {
-          await onStepCallback(block, result);
-        }
         return result;
       } else {
         // Recursive case: evaluate the recursive case block with the inputs
@@ -223,9 +208,6 @@ export const blockConfig: Record<BlockType, {
         const intermediateResult = await evaluate(block, inputs_decremented, evaluate, onStepCallback);
         const inputs_combined_with_previous = inputs_decremented.concat(intermediateResult);
         const result = await evaluate(block.children[1].block!, inputs_combined_with_previous, evaluate, onStepCallback);
-        if (onStepCallback) {
-          await onStepCallback(block, result);
-        }
         return result;
       }
     },
@@ -257,9 +239,6 @@ export const blockConfig: Record<BlockType, {
       while (depth < MAX_DEPTH) {
         const result = await evaluate(f_block, inputs.concat(n), evaluate, onStepCallback);
         if (result === 0) {
-          if (onStepCallback) {
-            await onStepCallback(block, n);
-          }
           return n;
         }
         n++;
@@ -282,9 +261,6 @@ export const blockConfig: Record<BlockType, {
       // Custom block evaluation logic
       if (block.children[0].block) {
         const result = await evaluate(block.children[0].block, inputs, evaluate, onStepCallback);
-        if (onStepCallback) {
-          await onStepCallback(block, result);
-        }
         return result;
       }
       throw new Error("Custom block is empty.");

--- a/recursive_blocks/src/BlockUtil.tsx
+++ b/recursive_blocks/src/BlockUtil.tsx
@@ -10,6 +10,7 @@ export interface BlockData {
   children: Array<BlockSlot>; // e.g., { condition: Block, then: Block }
   collapsed: boolean;
   immutable: boolean;
+  hasBreakpoint?: boolean;
   num_values?: Array<{ name: string; value: number }>; // e.g., { name: "n", value: 5 }
   inputCount: number;
   depth: number;

--- a/recursive_blocks/src/Toolbar.tsx
+++ b/recursive_blocks/src/Toolbar.tsx
@@ -6,8 +6,11 @@ interface ToolbarProps {
   onLoad: (event: React.ChangeEvent<HTMLInputElement>) => void;
   loadInputRef: React.RefObject<HTMLInputElement | null>;
   onRun: () => void;
+  onRunIgnoreBreakpoints: () => void;
   onHalt: () => void;
   onStep: () => void;
+  onResume: () => void;
+  paused: boolean;
   inputCount: number;
   onInputCountChange: (count: number) => void;
   inputs: number[];
@@ -23,9 +26,12 @@ export function Toolbar({
   onSave, 
   onLoad,
   loadInputRef, 
-  onRun, 
+  onRun,
+  onRunIgnoreBreakpoints,
   onHalt, 
   onStep,
+  onResume,
+  paused,
   inputCount,
   onInputCountChange,
   inputs,
@@ -155,8 +161,17 @@ export function Toolbar({
         </button>
         {openMenu === 'operations' && (
           <div className="dropdown-menu" onClick={(e) => e.stopPropagation()}>
-            <button onClick={() => { onRun(); closeMenus(); }} className="menu-item evaluate-button-menu">
-              Run
+            {paused ? (
+              <button onClick={() => { onResume(); closeMenus(); }} className="menu-item evaluate-button-menu">
+                Resume
+              </button>
+            ) : (
+              <button onClick={() => { onRun(); closeMenus(); }} className="menu-item evaluate-button-menu">
+                Run
+              </button>
+            )}
+            <button onClick={() => { onRunIgnoreBreakpoints(); closeMenus(); }} className="menu-item">
+              Run (Ignore Breakpoints)
             </button>
             <button onClick={() => { onHalt(); closeMenus(); }} className="menu-item halt-button-menu">
               Halt


### PR DESCRIPTION
Allow users to set and remove breakpoints on blocks. These breakpoints are dynamic (can be added and removed during execution).

Additional changes:
- the resume button will now respect breakpoints
- the new resume (ignore breakpoints) button will not
- reimplemented the step button to work with breakpoints
- fixed bugs with overall execution (onStepCallback called twice)