### PR TITLE
Improve notation handling

### DIFF
--- a/recursive_blocks/src/Block.css
+++ b/recursive_blocks/src/Block.css
@@ -794,3 +794,55 @@ label { color: var(--block-text-color); }
   text-align: center;
   background: rgba(255,255,255,0.25);
 }
+
+/* Notation popup */
+.notation-popup-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.notation-popup-panel {
+  width: min(680px, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: #ffffff;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+.notation-popup-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.notation-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.notation-popup-body {
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 6px;
+  background: #f7f7f7;
+  overflow: auto;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.notation-popup-close {
+  flex-shrink: 0;
+}

--- a/recursive_blocks/src/Block.tsx
+++ b/recursive_blocks/src/Block.tsx
@@ -7,6 +7,7 @@ import { ValueEditor } from "./ValueEditor";
 import { BlockSlotDisplay } from "./BlockSlot";
 import { useBlockEditor } from "./BlockEditorContext";
 import { PRTracePanel } from "./PRTracePanel";
+import { getHeaderNotation } from "./Notation";
 
 interface Props {
   block: BlockData | null;
@@ -63,31 +64,6 @@ const getSlotLabel = (blockType: BlockType, slotName: string): React.ReactNode =
       : <span>{slotName}</span>;
   }
   return slotName;
-};
-
-const getMathNotation = (block: BlockData): string => {
-  const n = block.inputCount ?? 0;
-  const args = (count: number, suffix?: string) => {
-    if (count === 0) return suffix ? `(${suffix})` : "()";
-    const vars = Array.from({ length: count }, (_, i) => `x${i + 1}`).join(", ");
-    return suffix ? `(${vars}, ${suffix})` : `(${vars})`;
-  };
-
-  switch (block.type) {
-    case "Zero": return `z${args(n)}`;
-    case "Successor": return `s(x)`;
-    case "Projection": {
-      const i = block.num_values?.find(v => v.name === "i")?.value ?? 1;
-      return `id[${i},${n}]${args(n)}`;
-    }
-    case "Composition": {
-      const m = block.num_values?.find(v => v.name === "m")?.value ?? 1;
-      return `C${n}[${m}]${args(n)}`;
-    }
-    case "Primitive Recursion": return `Pr[f,g]${args(n > 0 ? n - 1 : 0, "y")}`;
-    case "Minimization": return `Mn[f]${args(n)}`;
-    default: return "";
-  }
 };
 
 export function Block({ block, onUpdate, highlightedBlockId, selectedBlockId, onSelectBlock, isRunning = false }: Props) { 
@@ -182,7 +158,7 @@ export function Block({ block, onUpdate, highlightedBlockId, selectedBlockId, on
             <div>
               <div className="block-type">{block.name || blockConfig[block.type]?.displayName || block.type.toUpperCase()}</div>
               {block.type !== "Custom" && (
-                <div className="block-math-notation">{getMathNotation(block)}</div>
+                <div className="block-math-notation">{getHeaderNotation(block)}</div>
               )}
             </div>
           </div>

--- a/recursive_blocks/src/BlockEditor.tsx
+++ b/recursive_blocks/src/BlockEditor.tsx
@@ -45,6 +45,7 @@ export function BlockEditor() {
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
 
   const [currentResult, setCurrentResult] = useState<number | null>(null);
+  const [notationPopupText, setNotationPopupText] = useState<string | null>(null);
   const [isEvaluating, setIsEvaluating] = useState(false);
   const [evaluationSpeed, setEvaluationSpeed] = useState<number>(2);
   const [paused, setPaused] = useState(false);
@@ -125,12 +126,16 @@ export function BlockEditor() {
 
   const handleShowNotation = useCallback(() => {
     if (!rootBlock) {
-      alert("No root block to format.");
+      setNotationPopupText("No root block to format.");
       return;
     }
 
-    alert(getFormalNotation(rootBlock));
+    setNotationPopupText(getFormalNotation(rootBlock));
   }, [rootBlock]);
+
+  const handleCloseNotationPopup = useCallback(() => {
+    setNotationPopupText(null);
+  }, []);
 
   const handleDeleteSelectedBlock = useCallback(() => {
     if (!rootBlock || !selectedBlockId) return;
@@ -553,6 +558,20 @@ export function BlockEditor() {
       </div>
 
       <hr className="my-6" />
+
+      {notationPopupText !== null && (
+        <div className="notation-popup-overlay" role="dialog">
+          <div className="notation-popup-panel">
+            <div className="notation-popup-header">
+              <div className="notation-popup-title">Formal Notation</div>
+              <button className="toolbar-button notation-popup-close" onClick={handleCloseNotationPopup}>
+                Close
+              </button>
+            </div>
+            <pre className="notation-popup-body">{notationPopupText}</pre>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/recursive_blocks/src/BlockEditor.tsx
+++ b/recursive_blocks/src/BlockEditor.tsx
@@ -7,6 +7,7 @@ import { useBlockEditor } from "./BlockEditorContext";
 import { BlockSlotDisplay } from "./BlockSlot";
 import { BlockPalette } from "./BlockPalette";
 import { generateTrace, TraceEvent, TraceEventType, buildPRFrames, PRTraceFrame } from "./Trace";
+import { getFormalNotation } from "./Notation";
 
 export interface EditorSaveState {
   fileType: string;
@@ -121,6 +122,15 @@ export function BlockEditor() {
   const handleSave = useCallback(() => {
     createSaveFile(rootBlock ? serializeBlock(rootBlock) : undefined, inputs, inputCount > 0 ? inputCount : 0);
   }, [rootBlock, inputs, inputCount]);
+
+  const handleShowNotation = useCallback(() => {
+    if (!rootBlock) {
+      alert("No root block to format.");
+      return;
+    }
+
+    alert(getFormalNotation(rootBlock));
+  }, [rootBlock]);
 
   const handleDeleteSelectedBlock = useCallback(() => {
     if (!rootBlock || !selectedBlockId) return;
@@ -502,6 +512,7 @@ export function BlockEditor() {
       <Toolbar 
         onSave={handleSave}
         onLoad={handleLoad}
+        onShowNotation={handleShowNotation}
         loadInputRef={loadInputRef}
 
         onRun={handleRun}

--- a/recursive_blocks/src/Notation.ts
+++ b/recursive_blocks/src/Notation.ts
@@ -1,0 +1,144 @@
+import { BlockData } from "./BlockUtil";
+
+// Use unicode for sub and superscripts in the alert
+// When a UI panel is made for this, maybe handle them with react, but this is simpler
+const SUPERSCRIPT_DIGITS: Record<string, string> = {
+  "0": "\u2070",
+  "1": "\u00b9",
+  "2": "\u00b2",
+  "3": "\u00b3",
+  "4": "\u2074",
+  "5": "\u2075",
+  "6": "\u2076",
+  "7": "\u2077",
+  "8": "\u2078",
+  "9": "\u2079",
+};
+
+const SUBSCRIPT_DIGITS: Record<string, string> = {
+  "0": "\u2080",
+  "1": "\u2081",
+  "2": "\u2082",
+  "3": "\u2083",
+  "4": "\u2084",
+  "5": "\u2085",
+  "6": "\u2086",
+  "7": "\u2087",
+  "8": "\u2088",
+  "9": "\u2089",
+};
+
+const toScriptNumber = (value: number, map: Record<string, string>) =>
+  value.toString().split("").map(ch => map[ch] ?? ch).join("");
+
+const toSuperscript = (value: number) => toScriptNumber(value, SUPERSCRIPT_DIGITS);
+const toSubscript = (value: number) => toScriptNumber(value, SUBSCRIPT_DIGITS);
+
+// Builds generic input arguments like (x1, x2, ..., xN) for a given arity
+const inputArgs = (count: number) => {
+  if (count <= 0) return "()";
+  return `(${Array.from({ length: count }, (_, i) => `x${i + 1}`).join(", ")})`;
+};
+
+// Returns a named child slot's formal notation (or "?" when missing)
+const childFormal = (block: BlockData, slotName: string): string => {
+  const child = block.children.find(s => s.name === slotName)?.block;
+  return child ? getFormalNotation(child) : "?";
+};
+
+// Returns composition's g function child slots (g1..gm) in their stored order
+const compositionGSlots = (block: BlockData) => {
+  return block.children.filter(slot => slot.name.startsWith("g"));
+};
+
+export const getHeaderNotation = (block: BlockData): string => {
+  const n = block.inputCount ?? 0;
+  const args = inputArgs(n);
+
+  switch (block.type) {
+    case "Zero":
+      return `z${args}`;
+    case "Successor":
+      return `s${args}`;
+    case "Projection":
+      return `id[n, m]${args}`;
+    case "Composition": {
+      const gSymbols = compositionGSlots(block).map((_, i) => `g${i + 1}`);
+      return `Cn[${["f", ...gSymbols].join(", ")}]${args}`;
+    }
+    case "Primitive Recursion":
+      return `Pr[f, g]${args}`;
+    case "Minimization":
+      return `Mn[f]${args}`;
+    case "Custom":
+      return `${block.name ?? "Custom"}[h]${args}`;
+    default:
+      return `?${args}`;
+  }
+};
+
+export function getFormalNotation(block: BlockData): string {
+  switch (block.type) {
+    case "Successor":
+      return "s";
+    case "Zero":
+      return "z";
+    case "Projection": {
+      const n = block.inputCount ?? 0;
+      const m = block.num_values?.find(v => v.name === "i")?.value ?? 1;
+      return `id${toSuperscript(n)}${toSubscript(m)}`;
+    }
+    case "Composition": {
+      const fExpr = childFormal(block, "f");
+      const gExprs = compositionGSlots(block).map(slot => (slot.block ? getFormalNotation(slot.block) : "?"));
+      const suffix = gExprs.length > 0 ? `, ${gExprs.join(", ")}` : "";
+      return `Cn[${fExpr}${suffix}]`;
+    }
+    case "Primitive Recursion":
+      return `Pr[${childFormal(block, "Base Case")}, ${childFormal(block, "Recursive Case")}]`;
+    case "Minimization":
+      return `Mn[${childFormal(block, "f")}]`;
+    case "Custom":
+      return childFormal(block, "Custom Function");
+    default:
+      return "?";
+  }
+}
+
+export function getInformalNotation(
+  block: BlockData,
+  valueName?: string,
+  value?: number
+): { label: string; value: string } | null {
+  if (valueName !== undefined && value !== undefined) {
+    if (block.type === "Projection" && valueName === "i") {
+      const inputCount = Math.max(block.inputCount, value, 1);
+      const args = Array.from({ length: inputCount }, (_, i) => `x${i + 1}`).join(", ");
+
+      return {
+        label: `f(${args}) =`,
+        value: `x${value}`,
+      };
+    }
+
+    if (block.type === "Composition" && valueName === "m") {
+      return {
+        label: "arity \u2192",
+        value: `${value} inner block${value === 1 ? "" : "s"}`,
+      };
+    }
+
+    return {
+      label: `${valueName} \u2192`,
+      value: value.toString(),
+    };
+  }
+
+  const n = block.inputCount ?? 0;
+  const args = inputArgs(n);
+
+  if (block.type === "Zero") return { label: `f${args} =`, value: "0" };
+  if (block.type === "Successor") return { label: "f(x) =", value: "x + 1" };
+
+  return null;
+}

--- a/recursive_blocks/src/Notation.ts
+++ b/recursive_blocks/src/Notation.ts
@@ -1,7 +1,6 @@
 import { BlockData } from "./BlockUtil";
 
-// Use unicode for sub and superscripts in the alert
-// When a UI panel is made for this, maybe handle them with react, but this is simpler
+// Use unicode for sub and superscripts. Could be handled with react, but this is simpler
 const SUPERSCRIPT_DIGITS: Record<string, string> = {
   "0": "\u2070",
   "1": "\u00b9",

--- a/recursive_blocks/src/Toolbar.tsx
+++ b/recursive_blocks/src/Toolbar.tsx
@@ -6,6 +6,7 @@ import { MAX_INPUT_COUNT } from "./BlockEditor";
 interface ToolbarProps {
   onSave: () => void;
   onLoad: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onShowNotation: () => void;
   loadInputRef: React.RefObject<HTMLInputElement | null>;
   onRun: () => void;
   onForceRun: () => void;
@@ -26,6 +27,7 @@ interface ToolbarProps {
 export function Toolbar({ 
   onSave, 
   onLoad,
+  onShowNotation,
   loadInputRef, 
   onRun, 
   onForceRun,
@@ -84,6 +86,9 @@ export function Toolbar({
               disabled={isEvaluating}
             >
               {editMode && !isEvaluating ? "Editing" : "Edit"}
+            </button>
+            <button onClick={onShowNotation} className="toolbar-button" title="Show root formal notation">
+              Notation
             </button>
           </div>
         </div>

--- a/recursive_blocks/src/ValueEditor.tsx
+++ b/recursive_blocks/src/ValueEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { BlockData } from "./BlockUtil";
 import { blockConfig } from "./BlockConfig";
 import { useBlockEditor } from "./BlockEditorContext";
+import { getInformalNotation } from "./Notation";
 
 interface ValueEditorProps {
   block: BlockData;
@@ -9,44 +10,12 @@ interface ValueEditorProps {
   isRunning?: boolean;
 }
 
-const getDisplayOnlyNotation = (block: BlockData): { label: string; value: string } | null => {
-  const n = block.inputCount ?? 0;
-  const args = n === 0 ? "()" : `(${Array.from({ length: n }, (_, i) => `x${i + 1}`).join(", ")})`;
-  if (block.type === "Zero") return { label: `f${args} =`, value: "0" };
-  if (block.type === "Successor") return { label: "f(x) =", value: "x + 1" };
-  return null;
-};
-
 // JSX element that exists on a JSX Block element that represents the number values of the block, making them accessible to be updated.
 // If the block type doesn't have values, this element is an empty div.
 // Block is the block this value editor is on, and onUpdate is called when a value is updated.
 export function ValueEditor({ block, onUpdate, isRunning = false }: ValueEditorProps) {
   const [values, setValues] = useState(block.num_values ?? []);
   const { editMode } = useBlockEditor();
-
-  const formatStaticValue = (valueName: string, value: number) => {
-    if (block.type === "Projection" && valueName === "i") {
-      const inputCount = Math.max(block.inputCount, value, 1);
-      const args = Array.from({ length: inputCount }, (_, i) => `x${i + 1}`).join(", ");
-
-      return {
-        label: `f(${args}) =`,
-        value: `x${value}`,
-      };
-    }
-
-    if (block.type === "Composition" && valueName === "m") {
-      return {
-        label: "arity →",
-        value: `${value} inner block${value === 1 ? "" : "s"}`,
-      };
-    }
-
-    return {
-      label: `${valueName} →`,
-      value: value.toString(),
-    };
-  };
 
   useEffect(() => {
     if (JSON.stringify(values) !== JSON.stringify(block.num_values)) {
@@ -61,7 +30,7 @@ export function ValueEditor({ block, onUpdate, isRunning = false }: ValueEditorP
   };
 
   if (!values || values.length === 0) {
-    const notation = getDisplayOnlyNotation(block);
+    const notation = getInformalNotation(block);
     if (!notation) return;
     return (
       <div className="value-editor">
@@ -76,9 +45,10 @@ export function ValueEditor({ block, onUpdate, isRunning = false }: ValueEditorP
   }
 
   return (
-    <div className="value-editor">
+      <div className="value-editor">
       {values.map((val, index) => {
-        const staticValue = formatStaticValue(val.name, val.value);
+        const staticValue = getInformalNotation(block, val.name, val.value);
+        if (!staticValue) return null;
 
         return (
           <div key={index} className="value-field">


### PR DESCRIPTION
Added a panel to show the full formal notation of the root block. Also refactored notation handling across the codebase to 1 file (previously informal notation and block header notation were handled separately).

fixes #20 